### PR TITLE
Generic exceptions are no longer being caught - Issue #2 fixed

### DIFF
--- a/src/main/java/com/firebase/simplelogin/FirebaseSimpleLoginError.java
+++ b/src/main/java/com/firebase/simplelogin/FirebaseSimpleLoginError.java
@@ -2,6 +2,7 @@ package com.firebase.simplelogin;
 
 import com.firebase.client.FirebaseError;
 import com.firebase.simplelogin.enums.FirebaseSimpleLoginErrorCode;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.HashMap;
@@ -93,7 +94,9 @@ public class FirebaseSimpleLoginError {
           }
         }
       }
-      catch (Exception e) {
+      catch (JSONException e) {
+        // Invalid response. Default 'Unknown' error code will be used.
+        e.printStackTrace();
       }
     }
 

--- a/src/main/java/com/firebase/simplelogin/FirebaseUtils.java
+++ b/src/main/java/com/firebase/simplelogin/FirebaseUtils.java
@@ -1,11 +1,14 @@
 package com.firebase.simplelogin;
 
+import android.text.TextUtils;
+
 import com.firebase.client.Firebase;
 import com.firebase.simplelogin.enums.Provider;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
 
@@ -16,7 +19,7 @@ class FirebaseUtils {
     try {
       xurl = new URL(ref.toString());
     }
-    catch (Exception e) {
+    catch (MalformedURLException e) {
       throw new IllegalArgumentException("Invalid Firebase reference: " + ref, e);
     }
     String namespace = null;
@@ -33,13 +36,8 @@ class FirebaseUtils {
   }
 
   public static Provider providerForString(String provider) {
-    if (provider != null) {
-      try {
-        return Provider.valueOf(provider.trim().toUpperCase());
-      }
-      catch (Exception e) {
-        return Provider.INVALID;
-      }
+    if (!TextUtils.isEmpty(provider)) {
+      return Provider.valueOf(provider.trim().toUpperCase());
     }
     else {
       return Provider.INVALID;

--- a/src/main/java/com/firebase/simplelogin/JsonBasicResponseHandler.java
+++ b/src/main/java/com/firebase/simplelogin/JsonBasicResponseHandler.java
@@ -1,9 +1,13 @@
 package com.firebase.simplelogin;
 
+import java.io.IOException;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
+import org.apache.http.ParseException;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.util.EntityUtils;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
@@ -26,7 +30,11 @@ class JsonBasicResponseHandler implements ResponseHandler<JSONObject> {
         System.out.println(entityString);
         result = new JSONObject(entityString);
       }
-    } catch (Exception e) {
+    } catch (JSONException e) {
+      e.printStackTrace();
+    } catch (ParseException e) {
+      e.printStackTrace();
+    } catch (IOException e) {
       e.printStackTrace();
     }
     return result;

--- a/src/main/java/com/firebase/simplelogin/SimpleLogin.java
+++ b/src/main/java/com/firebase/simplelogin/SimpleLogin.java
@@ -44,8 +44,10 @@ import com.firebase.simplelogin.enums.FirebaseSimpleLoginErrorCode;
 import com.firebase.simplelogin.enums.Provider;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -168,7 +170,7 @@ public class SimpleLogin {
           JSONObject jsonObject = new JSONObject(jsonTokenData);
           attemptAuthWithData(jsonObject, handler);
         }
-        catch(Exception e) {
+        catch (JSONException e) {
           handler.authenticated(null, null);
         }
       }
@@ -200,7 +202,7 @@ public class SimpleLogin {
         handler.authenticated(FirebaseSimpleLoginError.errorFromResponse(null), null);
       }
     }
-    catch(Exception e) {
+    catch (JSONException e) {
       e.printStackTrace();
       handler.authenticated(FirebaseSimpleLoginError.errorFromResponse(null), null);
     }
@@ -247,7 +249,7 @@ public class SimpleLogin {
                 }
               }
             }
-            catch (Exception e) {
+            catch (JSONException e) {
               e.printStackTrace();
               FirebaseSimpleLoginError theError = FirebaseSimpleLoginError.errorFromResponse(null);
               completionHandler.authenticated(theError, null);
@@ -301,7 +303,7 @@ public class SimpleLogin {
                 }
               }
             }
-            catch (Exception e) {
+            catch (JSONException e) {
               e.printStackTrace();
               FirebaseSimpleLoginError theError = FirebaseSimpleLoginError.errorFromResponse(null);
               completionHandler.authenticated(theError, null);
@@ -371,7 +373,7 @@ public class SimpleLogin {
         }
       }
     }
-    catch (Exception e) {}
+    catch (JSONException e) {}
 
     // Save to shared prefs
     if(androidContext != null) {
@@ -383,7 +385,7 @@ public class SimpleLogin {
         jsonTokenData.put("userData", userData);
         editor.putString("jsonTokenData", jsonTokenData.toString());
       }
-      catch(Exception e) {
+      catch (JSONException e) {
         // TODO: log an error?
       }
       finally {
@@ -437,7 +439,7 @@ public class SimpleLogin {
                 completionHandler.authenticated(null, user);
               }
             }
-            catch (Exception e) {
+            catch (JSONException e) {
               e.printStackTrace();
               FirebaseSimpleLoginError theError = FirebaseSimpleLoginError.errorFromResponse(null);
               completionHandler.authenticated(theError, null);
@@ -488,7 +490,7 @@ public class SimpleLogin {
                 handler.completed(null, true);
               }
             }
-            catch(Exception e) {
+            catch (JSONException e) {
               e.printStackTrace();
               FirebaseSimpleLoginError theError = FirebaseSimpleLoginError.errorFromResponse(null);
               handler.completed(theError, false);
@@ -541,7 +543,7 @@ public class SimpleLogin {
                 handler.completed(null, true);
               }
             }
-            catch(Exception e) {
+            catch (JSONException e) {
               e.printStackTrace();
               FirebaseSimpleLoginError theError = FirebaseSimpleLoginError.errorFromResponse(null);
               handler.completed(theError, false);
@@ -587,7 +589,7 @@ public class SimpleLogin {
                   handler.completed(null, true);
                 }
               }
-              catch(Exception e) {
+              catch (JSONException e) {
                 e.printStackTrace();
                 FirebaseSimpleLoginError theError = FirebaseSimpleLoginError.errorFromResponse(null);
                 handler.completed(theError, false);
@@ -733,7 +735,7 @@ public class SimpleLogin {
                 }
               }
             }
-            catch (Exception e) {
+            catch (JSONException e) {
               e.printStackTrace();
               FirebaseSimpleLoginError theError = FirebaseSimpleLoginError.errorFromResponse(null);
               completionHandler.authenticated(theError, null);
@@ -763,7 +765,7 @@ public class SimpleLogin {
       try {
         result = httpClient.execute(httpGet, new JsonBasicResponseHandler());
       }
-      catch (Exception e) {
+      catch (IOException e) {
         e.printStackTrace();
       }
       return result;


### PR DESCRIPTION
Generic exceptions in most cases should never be caught because Exceptions which are never expected, such as RuntimeExceptions or ClassCastException, end up being caught in library-level error handling. Also, custom exceptions thrown by developers can get caught and exposed in unexpected manner to a developer.

With this commit all generic exceptions are removed and replaced with the actual exceptions being thrown.
